### PR TITLE
Add `.js` extension to all imports/re-exports

### DIFF
--- a/src/handle-requests-with.ts
+++ b/src/handle-requests-with.ts
@@ -1,6 +1,6 @@
-import { isTrackedPayload } from './is-tracked-payload';
-import { request } from './messages';
-import type { RequestHandler, TrackedPayload } from './public-types';
+import { isTrackedPayload } from './is-tracked-payload.js';
+import { request } from './messages.js';
+import type { RequestHandler, TrackedPayload } from './public-types.js';
 
 /** Create an event listener that watches requests made by this library for this library. */
 export function handleRequestsWith<RequestPayload, ResponsePayload>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { handleRequestsWith } from './handle-requests-with';
-export { sendRequest } from './send-request';
+export { handleRequestsWith } from './handle-requests-with.js';
+export { sendRequest } from './send-request.js';
 
-export type { TrackedPayload, ResolutionFunction, RequestHandler, ChannelController } from './public-types';
+export type { TrackedPayload, ResolutionFunction, RequestHandler, ChannelController } from './public-types.js';

--- a/src/is-tracked-payload.ts
+++ b/src/is-tracked-payload.ts
@@ -1,5 +1,5 @@
-import { request } from './messages';
-import type { TrackedPayload } from './public-types';
+import { request } from './messages.js';
+import type { TrackedPayload } from './public-types.js';
 
 export function isTrackedPayload<PayloadType>(incoming: any): incoming is TrackedPayload<PayloadType> {
   if (typeof incoming === 'object' && incoming !== null && 'type' in incoming && 'id' in incoming) {

--- a/src/promise-registry.ts
+++ b/src/promise-registry.ts
@@ -1,5 +1,5 @@
-import type { ResolutionFunction, TrackedPayload } from './public-types';
-import { request } from './messages';
+import type { ResolutionFunction, TrackedPayload } from './public-types.js';
+import { request } from './messages.js';
 
 const registry = new Map<number, ResolutionFunction<unknown>>();
 let idCounter = 0;

--- a/src/public-types.ts
+++ b/src/public-types.ts
@@ -1,4 +1,4 @@
-import type { request } from './messages';
+import type { request } from './messages.js';
 
 export interface TrackedPayload<OriginalPayloadType> {
   id: number;

--- a/src/send-request.ts
+++ b/src/send-request.ts
@@ -1,6 +1,6 @@
-import { stamp, resolveByID } from './promise-registry';
-import { isTrackedPayload } from './is-tracked-payload';
-import type { Client } from './lib.webworker';
+import { stamp, resolveByID } from './promise-registry.js';
+import { isTrackedPayload } from './is-tracked-payload.js';
+import type { Client } from './lib.webworker.js';
 
 function catchResponse<ResponsePayloadType>(event: MessageEvent<unknown>) {
   if (isTrackedPayload<ResponsePayloadType>(event.data)) {


### PR DESCRIPTION
According to [MDN Docs - Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#:~:text=This%20doesn%27t%20work%20in%20native%20JavaScript%20modules), the standard ES6 imports must be fully qualified, meaning that they have to contain the extension as well. The same behavior can also be observed in [Node's ESM docs](https://nodejs.org/api/esm.html#esm_mandatory_file_extensions), and is the default behavior (though customizable) in [Webpack](https://webpack.js.org/configuration/module/#resolvefullyspecified). In short, all imports must have the `.js` extension to be resolved correctly.
Since TypeScript does not rewrite import paths (and doesn't plan to - not even with path aliases), it is necessary to add the `.js` extension manually to all imports. According to [this Stack Overflow answer](https://stackoverflow.com/a/62626938), TypeScript has no problem with writing the `.js` extension explicitly (even though the file is actually `.ts`) and can still resolve it properly, so that's the way to go.

_Note: this may not have been necessary in type-only imports, but I still added them for consistency._